### PR TITLE
Upgrade | Use saloonphp/saloon instead of Sammyjo20/Saloon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "sammyjo20/saloon": "^1.0",
+        "saloonphp/saloon": "^1.0",
         "spatie/data-transfer-object": "^1.0 | ^2.0 | ^3.7"
     },
     "require-dev": {


### PR DESCRIPTION
This PR just changes the package name from `sammyjo20/saloon` to `saloonphp/saloon`. 

Have a great day!